### PR TITLE
Add Agent QA to related QA tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When an AI agent reads a skill file, it follows the `SKILL.md` guidelines to gen
 
 ### Related QA tooling
 
-- [Agent QA](https://github.com/vostride/agent-qa) — Open-source, self-improving QA agent for software teams. It can exercise generated web and mobile interfaces through natural-language tests, retain testing context, and self-heal tests as applications change.
+- [Agent QA](https://github.com/vostride/agent-qa) — Source-available, self-improving QA agent for software teams. It can exercise generated web and mobile interfaces through natural-language tests, retain testing context, and self-heal tests as applications change.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -442,6 +442,10 @@ A design skill is a folder containing `SKILL.md` and `DESIGN.md`.
 
 When an AI agent reads a skill file, it follows the `SKILL.md` guidelines to generate UI code that is consistent, accessible, and true to the design system.
 
+### Related QA tooling
+
+- [Agent QA](https://github.com/vostride/agent-qa) — Open-source, self-improving QA agent for software teams. It can exercise generated web and mobile interfaces through natural-language tests, retain testing context, and self-heal tests as applications change.
+
 ## Usage
 
 ### Pull a skill into your project


### PR DESCRIPTION
## Summary

- add Agent QA under a clearly labeled related-QA subsection
- connect the design-skill quality gates to a tool that can exercise generated web and mobile interfaces
- keep the entry separate from the registry's actual design skills

Agent QA is an source-available, self-improving QA agent for software teams. It supports natural-language testing, persistent testing context, and self-healing tests as applications change.

Project: https://github.com/vostride/agent-qa

## Validation

- `git diff --check`
- verified the project and documentation links

License note: Agent QA's current FSL-1.1-ALv2 release is source-available rather than OSI open source and converts to Apache-2.0 after two years.

Disclosure: I am affiliated with Agent QA and Vostride.